### PR TITLE
added expanded property

### DIFF
--- a/events-calendar.html
+++ b/events-calendar.html
@@ -103,6 +103,12 @@
                     observer: "_handlerChosen"
                 },
 
+                // Choose to expand the calendar on initialisation
+                expanded: {
+                    type: Boolean,
+                    value: false
+                },
+
                 // Set the first day of the week: Sunday is 0, Monday is 1, etc.
                 firstDayOfWeek: {
                     type: Number,
@@ -390,6 +396,7 @@
 
                 for (var i = 0; i < self.showDaysInMonth; i++) {
                     var day = document.createElement('events-calendar-day');
+                    day.open = this.expanded
                     // separated into weeks
                     if (i % 7 === 0) {
                         var week = document.createElement('div');


### PR DESCRIPTION
added expanded property, to let the days be expanded depending on the property value on events-calendar, not events-calendar-days. It changes the events-calendar-days.open property; but now you can set it in your markup as prop like:
```
<events-calendar day-labels='["Su","Mo","Tu","We","Th","Fr","Sa"]'
                 disable-prev-days
                 show-days-in-month=35
                 expanded
    >
    </events-calendar>
```
